### PR TITLE
Reorder and rename type parameters for predictability.

### DIFF
--- a/Registric/IReference.cs
+++ b/Registric/IReference.cs
@@ -3,16 +3,16 @@
     /// <summary>
     /// A refernce to an object within a given register, that may or may not currently exist at the time that it's returned.
     /// </summary>
-    /// <typeparam name="T">The objects type.</typeparam>
     /// <typeparam name="TKey">The type of value used to key the register.</typeparam>
-    public interface IReference<T, TKey>
-        where T : notnull
+    /// <typeparam name="TValue">The objects type.</typeparam>
+    public interface IReference<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
         /// <summary>
         /// The key identifying the object within it's respective register.
         /// </summary>
-        public RegisterKey<T, TKey> Key { get; }
+        public RegisterKey<TKey, TValue> Key { get; }
 
 
 
@@ -21,6 +21,6 @@
         /// </summary>
         /// <returns></returns>
         /// <exception cref="MissingAssociationException">The referenced object didn't exist.</exception>
-        public T Get();
+        public TValue Get();
     } // end interface
 } // end namespace

--- a/Registric/IRegister.cs
+++ b/Registric/IRegister.cs
@@ -3,11 +3,11 @@
     /// <summary>
     /// Contract for a object register.
     /// </summary>
-    /// <typeparam name="T">The type of object held.</typeparam>
     /// <typeparam name="TKey"></typeparam>
-    public interface IRegister<T, TKey>
-        where T : notnull
+    /// <typeparam name="TValue">The type of object held.</typeparam>
+    public interface IRegister<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
         /// <summary>
         /// The number of register keys bound to this register, both associated with a value or not.
@@ -48,7 +48,7 @@
         /// <param name="key">The key identifying the object.</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">Register is closed, and can't promise further values.</exception>
-        public IReference<T, TKey> Get(TKey key);
+        public IReference<TKey, TValue> Get(TKey key);
 
         /// <summary>
         /// Associates a value with 
@@ -58,7 +58,7 @@
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">Register is closed, and can't try to associate further values.</exception>
         /// <exception cref="KeyCollisionException">An object had already been associated with that key.</exception>
-        public IReference<T, TKey> AssociateValue(TKey key, T value);
+        public IReference<TKey, TValue> Associate(TKey key, TValue value);
 
     } // end interface
 } // end namespace

--- a/Registric/KeyCollisionException.cs
+++ b/Registric/KeyCollisionException.cs
@@ -10,9 +10,9 @@
 		/// Construct an exception with a message indicating what key the error emerged from.
 		/// </summary>
 		/// <param name="key">The excepting key.</param>
-        public static KeyCollisionException Of<T, TKey>(RegisterKey<T, TKey> key)
-            where T : notnull
-            where TKey : notnull => new KeyCollisionException($"Key collision for: \"{key}\".");
+        public static KeyCollisionException Of<TKey, TValue>(RegisterKey<TKey, TValue> key)
+            where TKey : notnull
+            where TValue : notnull => new($"Key collision for: \"{key}\".");
 
 
 

--- a/Registric/MissingAssociationException.cs
+++ b/Registric/MissingAssociationException.cs
@@ -1,7 +1,7 @@
 ﻿namespace GSR.Registric
 {
     /// <summary>
-    /// A key wasn't associated in a <see cref="IRegister{T, TKey}"/> when it was expected to be.
+    /// A key wasn't associated in a <see cref="IRegister{TKey, TValue}"/> when it was expected to be.
     /// </summary>
     [Serializable]
     public class MissingAssociationException : Exception
@@ -11,9 +11,9 @@
         /// Construct an exception with a message indicating what key the error emerged from.
         /// </summary>
         /// <param name="key">The excepting key.</param>
-        public static MissingAssociationException Of<T, TKey>(RegisterKey<T, TKey> key)
-            where T : notnull
-            where TKey : notnull => new MissingAssociationException($"Object missing for: \"{key}\".");
+        public static MissingAssociationException Of<TKey, TValue>(RegisterKey<TKey, TValue> key)
+            where TKey : notnull
+            where TValue : notnull => new MissingAssociationException($"Object missing for: \"{key}\".");
 
 
 

--- a/Registric/Reference.cs
+++ b/Registric/Reference.cs
@@ -3,27 +3,27 @@
 namespace GSR.Registric
 {
     /// <summary>
-    /// Simple <see cref="IReference{T, TKey}"/> implementation.
+    /// Simple <see cref="IReference{Tkey, TValue}"/> implementation.
     /// </summary>
-    /// <typeparam name="T">The type of object referenced.</typeparam>
     /// <typeparam name="TKey"></typeparam>
-    public sealed class Reference<T, TKey> : IReference<T, TKey>
-        where T : notnull
+    /// <typeparam name="TValue">The type of object referenced.</typeparam>
+    public sealed class Reference<TKey, TValue> : IReference<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
         /// <inheritdoc/>
-        public RegisterKey<T, TKey> Key { get; }
+        public RegisterKey<TKey, TValue> Key { get; }
 
-        private Lazy<T> _value;
+        private Lazy<TValue> _value;
 
 
 
         /// <summary>
-        /// Constructs an <see cref="Reference{T, TKey}"/>.
+        /// Constructs an <see cref="Reference{TKey, TValue}"/>.
         /// </summary>
         /// <param name="key">The key of the object the reference refers to.</param>
         /// <param name="value">The providersof the value.</param>
-        public Reference(RegisterKey<T, TKey> key, Lazy<T> value)
+        public Reference(RegisterKey<TKey, TValue> key, Lazy<TValue> value)
         {
             Key = key.IsNotNull();
             _value = value.IsNotNull();
@@ -31,7 +31,7 @@ namespace GSR.Registric
 
 
         /// <inheritdoc/>
-        public T Get() => this.IsPopulated()
+        public TValue Get() => this.IsPopulated()
             ? _value.Value
             : throw new MissingAssociationException("The object wasn't present in the register.");
     } // end class

--- a/Registric/Register.cs
+++ b/Registric/Register.cs
@@ -3,17 +3,17 @@
 namespace GSR.Registric
 {
     /// <summary>
-    /// Simple <see cref="IRegister{T, TKey}"/> implementation.
+    /// Simple <see cref="IRegister{TKey, TValue}"/> implementation.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
     /// <typeparam name="TKey"></typeparam>
-    public sealed class Register<T, TKey> : IRegister<T, TKey>
-        where T : notnull
+    public sealed class Register<TKey, TValue> : IRegister<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
-        private readonly IDictionary<TKey, T> _loaded = new Dictionary<TKey, T>();
+        private readonly IDictionary<TKey, TValue> _loaded = new Dictionary<TKey, TValue>();
 
-        private readonly IDictionary<TKey, IReference<T, TKey>> _promised = new Dictionary<TKey, IReference<T, TKey>>();
+        private readonly IDictionary<TKey, IReference<TKey, TValue>> _promised = new Dictionary<TKey, IReference<TKey, TValue>>();
 
         /// <inheritdoc/>
         public int Count => _promised.Count;
@@ -55,20 +55,20 @@ namespace GSR.Registric
         public bool Promised(TKey key) => _promised.ContainsKey(key);
 
         /// <inheritdoc/>
-        public IReference<T, TKey> Get(TKey key)
+        public IReference<TKey, TValue> Get(TKey key)
         {
             if (!Promised(key))
                 if (_isClosed)
                     throw new InvalidOperationException("Register is closed, can't promise any further values.");
                 else
-                    _promised[key] = new Reference<T, TKey>(this.CreateKey(key), new Lazy<T>(() => _loaded[key]));
+                    _promised[key] = new Reference<TKey, TValue>(this.CreateKey(key), new Lazy<TValue>(() => _loaded[key]));
 
             return _promised[key];
         } // end Get()
 
 
         /// <inheritdoc/>
-        public IReference<T, TKey> AssociateValue(TKey key, T value)
+        public IReference<TKey, TValue> Associate(TKey key, TValue value)
         {
             if (_isClosed)
                 throw new InvalidOperationException("Register is closed, can't associate any further values.");

--- a/Registric/RegisterKey.cs
+++ b/Registric/RegisterKey.cs
@@ -6,14 +6,14 @@ namespace GSR.Registric
     /// <summary>
     /// Key uniquely identifying an object registered within a register.
     /// </summary>
-    public struct RegisterKey<T, TKey>
-        where T : notnull
+    public struct RegisterKey<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
         /// <summary>
         /// The register that the key belongs to.
         /// </summary>
-        public IRegister<T, TKey> Register { get; }
+        public IRegister<TKey, TValue> Register { get; }
 
         /// <summary>
         /// The registered objects unique identifier.
@@ -27,7 +27,7 @@ namespace GSR.Registric
         /// </summary>
         /// <param name="register"></param>
         /// <param name="key"></param>
-        public RegisterKey(IRegister<T, TKey> register, TKey key)
+        public RegisterKey(IRegister<TKey, TValue> register, TKey key)
         {
             Register = register.IsNotNull();
             Key = key.IsNotNull();
@@ -43,15 +43,15 @@ namespace GSR.Registric
 
         /// <inheritdoc/>
         public override bool Equals([NotNullWhen(true)] object? obj) =>
-            obj is RegisterKey<T, TKey> rk &&
+            obj is RegisterKey<TKey, TValue> rk &&
             ReferenceEquals(Register, rk.Register) &&
             Key.Equals(rk.Key);
 
         /// <inheritdoc/>
-        public static bool operator ==(RegisterKey<T, TKey> left, RegisterKey<T, TKey> right) => left.Equals(right);
+        public static bool operator ==(RegisterKey<TKey, TValue> left, RegisterKey<TKey, TValue> right) => left.Equals(right);
 
         /// <inheritdoc/>
-        public static bool operator !=(RegisterKey<T, TKey> left, RegisterKey<T, TKey> right) => !(left == right);
+        public static bool operator !=(RegisterKey<TKey, TValue> left, RegisterKey<TKey, TValue> right) => !(left == right);
 
     } // end record
 } // end namespace

--- a/Registric/Registric.csproj
+++ b/Registric/Registric.csproj
@@ -9,7 +9,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageId>gsr_registric</PackageId>
     <Title>GSR Registric</Title>
-    <Version>2.0.0.0</Version>
+    <Version>2.1.0.0</Version>
     <Authors>GSR</Authors>
     <Company>GSR</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Registric/Util.cs
+++ b/Registric/Util.cs
@@ -8,79 +8,79 @@
         /// <summary>
         /// Is the referenced object currently present in the register.
         /// </summary>
-        public static bool IsPopulated<T, TKey>(this IReference<T, TKey> reference)
-            where T : notnull
+        public static bool IsPopulated<TKey, TValue>(this IReference<TKey, TValue> reference)
             where TKey : notnull
+            where TValue : notnull
             => reference.Key.Register.Contains(reference.Key);
 
         /// <summary>
         /// Create a key for a given register.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
         /// <typeparam name="TKey"></typeparam>
-        /// <param name="r"></param>
+        /// <param name="register"></param>
         /// <param name="key"></param>
         /// <returns></returns>
-        public static RegisterKey<T, TKey> CreateKey<T, TKey>(this IRegister<T, TKey> r, TKey key)
-            where T : notnull
+        public static RegisterKey<TKey, TValue> CreateKey<TKey, TValue>(this IRegister<TKey, TValue> register, TKey key)
             where TKey : notnull
-            => new(r, key);
+            where TValue : notnull
+            => new(register, key);
 
 
 
         /// <summary>
-        /// Call <see cref="IRegister{T, TKey}.Contains(TKey)"/> using a RegisterKey.
+        /// Call <see cref="IRegister{TKey, TValue}.Contains(TKey)"/> using a RegisterKey.
         /// </summary>
-        public static bool Contains<T, TKey>(this IRegister<T, TKey> r, RegisterKey<T, TKey> key)
-            where T : notnull
-            where TKey : notnull 
-            => ReferenceEquals(r, key.Register) && r.Contains(key.Key);
+        public static bool Contains<TKey, TValue>(this IRegister<TKey, TValue> register, RegisterKey<TKey, TValue> key)
+            where TKey : notnull
+            where TValue : notnull
+            => ReferenceEquals(register, key.Register) && register.Contains(key.Key);
 
         /// <summary>
-        /// Call <see cref="IRegister{T, TKey}.Promised(TKey)"/> using a RegisterKey.
+        /// Call <see cref="IRegister{TKey, TValue}.Promised(TKey)"/> using a RegisterKey.
         /// </summary>
-        public static bool Promised<T, TKey>(this IRegister<T, TKey> r, RegisterKey<T, TKey> key)
-            where T : notnull
+        public static bool Promised<TKey, TValue>(this IRegister<TKey, TValue> register, RegisterKey<TKey, TValue> key)
             where TKey : notnull 
-            => ReferenceEquals(r, key.Register) && r.Promised(key.Key);
+            where TValue : notnull
+            => ReferenceEquals(register, key.Register) && register.Promised(key.Key);
 
         /// <summary>
-        /// Call <see cref="IRegister{T, TKey}.Get(TKey)"/> using a RegisterKey.
+        /// Call <see cref="IRegister{TKey, TValue}.Get(TKey)"/> using a RegisterKey.
         /// </summary>
-        public static IReference<T, TKey> Get<T, TKey>(this IRegister<T, TKey> r, RegisterKey<T, TKey> key)
-            where T : notnull
+        public static IReference<TKey, TValue> Get<TKey, TValue>(this IRegister<TKey, TValue> register, RegisterKey<TKey, TValue> key)
             where TKey : notnull 
-            => ReferenceEquals(r, key.Register) 
-                ? r.Get(key.Key) 
+            where TValue : notnull
+            => ReferenceEquals(register, key.Register) 
+                ? register.Get(key.Key) 
                 : throw new InvalidOperationException("Key didn't belong to the register it was attemptedly used on.");
 
         /// <summary>
-        /// Call <see cref="IRegister{T, TKey}.AssociateValue(TKey, T)"/> using a RegisterKey.
+        /// Call <see cref="IRegister{TKey, TValue}.Associate(TKey, TValue)"/> using a RegisterKey.
         /// </summary>
-        public static IReference<T, TKey> AssociateValue<T, TKey>(this IRegister<T, TKey> r, RegisterKey<T, TKey> key, T value)
-            where T : notnull
+        public static IReference<TKey, TValue> Associate<TKey, TValue>(this IRegister<TKey, TValue> register, RegisterKey<TKey, TValue> key, TValue value)
             where TKey : notnull
-            => ReferenceEquals(r, key.Register)
-                ? r.AssociateValue(key.Key, value)
+            where TValue : notnull
+            => ReferenceEquals(register, key.Register)
+                ? register.Associate(key.Key, value)
                 : throw new InvalidOperationException("Key didn't belong to the register it was attemptedly used on.");
 
 
 
         /// <summary>
-        /// Get's an <see cref="IReference{T, TKey}"/> to the value associated with the register key.
+        /// Get's an <see cref="IReference{TKey, TValue}"/> to the value associated with the register key.
         /// </summary>
-        public static IReference<T, TKey> Get<T, TKey>(this RegisterKey<T, TKey> key)
-            where T : notnull
+        public static IReference<TKey, TValue> Get<TKey, TValue>(this RegisterKey<TKey, TValue> key)
             where TKey : notnull
+            where TValue : notnull
             => key.Register.Get(key.Key);
 
         /// <summary>
         /// Creates an association between the key and a value.
         /// </summary>
-        public static IReference<T, TKey> AssociateValue<T, TKey>(this RegisterKey<T, TKey> key, T value)
-            where T : notnull
+        public static IReference<TKey, TValue> AssociateValue<TKey, TValue>(this RegisterKey<TKey, TValue> key, TValue value)
             where TKey : notnull
-            => key.Register.AssociateValue(key.Key, value);
+            where TValue : notnull
+            => key.Register.Associate(key.Key, value);
 
 
     } // end class

--- a/RegistricTests/FakeRegister.cs
+++ b/RegistricTests/FakeRegister.cs
@@ -2,9 +2,9 @@
 
 namespace GSR.Tests.Registric
 {
-    public sealed class FakeRegister<T, TKey> : IRegister<T, TKey>
-        where T : notnull
+    public sealed class FakeRegister<TKey, TValue> : IRegister<TKey, TValue>
         where TKey : notnull
+        where TValue : notnull
     {
         public int Count => throw new NotImplementedException();
 
@@ -27,17 +27,17 @@ namespace GSR.Tests.Registric
 
 
 
-        public IReference<T, TKey> AssociateValue(TKey key, T value)
+        public IReference<TKey, TValue> Associate(TKey key, TValue value)
         {
             throw new NotImplementedException();
-        }
+        } // end AssociateValue()
 
         public bool Contains(TKey key) => _contains(key);
 
-        public IReference<T, TKey> Get(TKey key)
+        public IReference<TKey, TValue> Get(TKey key)
         {
             throw new NotImplementedException();
-        }
+        } // end Get()
 
         public bool Promised(TKey key) => _promised(key);
 

--- a/RegistricTests/TestReference.cs
+++ b/RegistricTests/TestReference.cs
@@ -10,9 +10,9 @@ namespace GSR.Tests.Registric
         [DataRow(0)]
         public void TestGet(int value)
         {
-            IRegister<int, string> r = new FakeRegister<int, string>(contains: (r) => true, promised: (r) => true);
-            RegisterKey<int, string> rk = new(r, "test.gsr.key");
-            IReference<int, string> rr = new Reference<int, string>(rk, new Lazy<int>(() => value));
+            IRegister<string, int> r = new FakeRegister<string, int>(contains: (r) => true, promised: (r) => true);
+            RegisterKey<string, int> rk = new(r, "test.gsr.key");
+            IReference<string, int> rr = new Reference<string, int>(rk, new Lazy<int>(() => value));
             Assert.AreEqual(value, rr.Get());
         } // end TestGet()
 
@@ -21,9 +21,9 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(MissingAssociationException))]
         public void TestGetUnassociated()
         {
-            IRegister<int, string> r = new FakeRegister<int, string>(contains: (r) => false, promised: (r) => true);
-            RegisterKey<int, string> rk = new(r, "test.gsr.key");
-            IReference<int, string> rr = new Reference<int, string>(rk, new Lazy<int>(() => throw new Exception()));
+            IRegister<string, int> r = new FakeRegister<string, int>(contains: (r) => false, promised: (r) => true);
+            RegisterKey<string, int> rk = new(r, "test.gsr.key");
+            IReference<string, int> rr = new Reference<string, int>(rk, new Lazy<int>(() => throw new Exception()));
             rr.Get();
         } // end TestGetUnloaded()
 

--- a/RegistricTests/TestRegister.cs
+++ b/RegistricTests/TestRegister.cs
@@ -9,8 +9,8 @@ namespace GSR.Tests.Registric
         public void TestGet()
         {
             string key = "test.gsr.key";
-            IRegister<int, string> r = new Register<int, string>();
-            RegisterKey<int, string> rk = new(r, key);
+            IRegister<string, int> r = new Register<string, int>();
+            RegisterKey<string, int> rk = new(r, key);
 
             Assert.IsFalse(r.Promised(rk));
             Assert.AreEqual(rk, r.Get(key).Key);
@@ -22,20 +22,20 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(MissingAssociationException))]
         public void TestUnwrapGottenReferenceBeforeAssociation()
         {
-            new Register<int, string>().Get("a").Get();
+            new Register<string, int>().Get("a").Get();
         } // end TestUnwrapReferenceEarly()
 
 
         [TestMethod]
         public void TestAssociateValue()
         {
-            IRegister<int, string> r = new Register<int, string>();
+            IRegister<string, int> r = new Register<string, int>();
 
             string key = "";
             int value = 64 ^ 2;
             Assert.IsFalse(r.Contains(key));
             Assert.IsFalse(r.Promised(key));
-            IReference<int, string> rr = r.AssociateValue(key, value);
+            IReference<string, int> rr = r.Associate(key, value);
             Assert.AreEqual(key, rr.Key.Key);
             Assert.AreEqual(value, rr.Get());
             Assert.IsTrue(r.Contains(key));
@@ -45,17 +45,17 @@ namespace GSR.Tests.Registric
         [TestMethod]
         public void TestAssociateValueTwice()
         {
-            IRegister<int, string> r = new Register<int, string>();
+            IRegister<string, int> r = new Register<string, int>();
 
             string key1 = "";
             string key2 = "-";
             int value = 64 ^ 2;
 
-            IReference<int, string> rr1 = r.AssociateValue(key1, value);
+            IReference<string, int> rr1 = r.Associate(key1, value);
             Assert.AreEqual(key1, rr1.Key.Key);
             Assert.AreEqual(value, rr1.Get());
 
-            IReference<int, string> rr2 = r.AssociateValue(key2, value);
+            IReference<string, int> rr2 = r.Associate(key2, value);
             Assert.AreEqual(key2, rr2.Key.Key);
             Assert.AreEqual(value, rr2.Get());
         } // end TestAssociateValueTwice()
@@ -64,13 +64,13 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(KeyCollisionException))]
         public void TestAssociateKeyCollision()
         {
-            IRegister<int, string> r = new Register<int, string>();
+            IRegister<string, int> r = new Register<string, int>();
 
             string key = "";
             int value1 = 64 ^ 2;
             int value2 = 62;
-            r.AssociateValue(key, value1);
-            r.AssociateValue(key, value2);
+            r.Associate(key, value1);
+            r.Associate(key, value2);
         } // end TestAssociateKeyCollision()
 
 
@@ -78,15 +78,15 @@ namespace GSR.Tests.Registric
         [TestMethod]
         public void TestCloseWithNone()
         {
-            new Register<int, string>().Close();
+            new Register<string, int>().Close();
         } // end TestCloseWithNone()
 
         [TestMethod]
         public void TestCloseWithAssociated()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
-            r.AssociateValue("ejh", 904032);
+            r.Associate("ejh", 904032);
             r.Close();
         } // end TestCloseWithAssociated()
 
@@ -94,7 +94,7 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(AggregateException))]
         public void TestCloseWithUnassociated()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
             r.Get(";;;;;;;;;;;;;;;;;;;");
             r.Close();
@@ -103,11 +103,11 @@ namespace GSR.Tests.Registric
         [TestMethod]
         public void TestGetExistingAfterClosure()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
             string b = "304";
             int value = 85930258;
-            r.AssociateValue(b, value);
+            r.Associate(b, value);
             r.Close();
             Assert.AreEqual(value, r.Get(b).Get());
         } // end TestGetExistingAfterClosure()
@@ -116,7 +116,7 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(InvalidOperationException))]
         public void TestGetNewAfterClosure()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
             r.Close();
             r.Get("304");
@@ -126,22 +126,22 @@ namespace GSR.Tests.Registric
         [ExpectedException(typeof(InvalidOperationException))]
         public void TestAssociateNewValueAfterClosure()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
             r.Close();
-            r.AssociateValue("304", default);
+            r.Associate("304", default);
         } // end TestAssociateNewValueAfterClosure()
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void TestAssociateExistingValueAfterClosure()
         {
-            Register<int, string> r = new Register<int, string>();
+            Register<string, int> r = new Register<string, int>();
 
             string k = "3459jmivgowe";
-            r.AssociateValue(k, 0);
+            r.Associate(k, 0);
             r.Close();
-            r.AssociateValue(k, default);
+            r.Associate(k, default);
         } // end TestAssociateNewValueAfterClosure()
 
     } // end class

--- a/RegistricTests/TestRegisterKey.cs
+++ b/RegistricTests/TestRegisterKey.cs
@@ -11,11 +11,11 @@ namespace GSR.Tests.Registric
         [DataRow("gsr.alpha.beta", "gsr", ".alpha.beta")]
         public void TestEquality(string a, string b, string c)
         {
-            IRegister<int, string> r = new Register<int, string>();
+            IRegister<string, int> r = new Register<string, int>();
 
             Assert.AreEqual(
-                new RegisterKey<int, string>(r, a),
-                new RegisterKey<int, string>(r, b + c));
+                new RegisterKey<string, int>(r, a),
+                new RegisterKey<string, int>(r, b + c));
         } // end TestEquality()
 
         [TestMethod]
@@ -24,11 +24,11 @@ namespace GSR.Tests.Registric
         [DataRow("gsr.alpha.beta", "gsr", ".beta.alpha")]
         public void TestInequality1(string a, string b, string c)
         {
-            IRegister<int, string> r = new Register<int, string>();
+            IRegister<string, int> r = new Register<string, int>();
 
             Assert.AreNotEqual(
-                new RegisterKey<int, string>(r, a),
-                new RegisterKey<int, string>(r, b + c));
+                new RegisterKey<string, int>(r, a),
+                new RegisterKey<string, int>(r, b + c));
         } // end TestInequality1()
 
         [TestMethod]
@@ -39,8 +39,8 @@ namespace GSR.Tests.Registric
         {
 
             Assert.AreNotEqual(
-                new RegisterKey<int, string>(new Register<int, string>(), a),
-                new RegisterKey<int, string>(new Register<int, string>(), b + c));
+                new RegisterKey<string, int>(new Register<string, int>(), a),
+                new RegisterKey<string, int>(new Register<string, int>(), b + c));
         } // end TestInequality2()
 
     } // end class


### PR DESCRIPTION
- Rename: IRegister.AssociateValue -> IRegister.Associate.
- Rename: Util.AssociateValue -> Util.Associate.